### PR TITLE
Fix commit history expansion for the first element

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8000/ui",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+To debug this code you can use VS Code IDE:
+
+1. Navigate to 'MCP' folder and start local web server:
+        python3 -m http.server
+2. Load MCP folder into your VS Code workspace (File | Add Folder to Workspace...)
+3. Click on Run | Start Debugging menu in VS Code
+4. Set a breakpoint in .js file if needed - execution will pause there and vars can be inspected, etc.

--- a/ui/js/ui.js
+++ b/ui/js/ui.js
@@ -298,7 +298,19 @@ function hashChange( event )
                 $( this ).find('a').attr( 'data-target', $( this ).find('a').attr( 'data-target' ) + '-latest' );
                 $( this ).find('.sublinks').attr( 'id', $( this ).find('.sublinks').attr( 'id' ) + '-latest' );
               });
-              latestCommitEntry.html($("#project-commit-list div:first").clone())
+
+              // Need to clone first div from commitEntries to latestCommitEntry element.
+              // Plain clone won't work since all of the event handlers would only work on the first added div
+              // thus original div will not collapse independently. Therefore we are updating the data target value
+              // of the collapsible section (<a>) and the id of the element providing data (<div> using 'sublinks' class)
+              var firstCommitClone = $("#project-commit-list div:first").clone();
+              var cloneCollapsible = firstCommitClone.find('a'); // found collapsible section element
+              cloneCollapsible.attr('data-target', cloneCollapsible.attr('data-target') + 1);
+              var cloneTarget = firstCommitClone.find('.sublinks'); // found section contents element
+              cloneTarget.attr('id', cloneTarget.attr('id') + 1);
+
+              // add latest commit contents to the document
+              firstCommitClone.appendTo(latestCommitEntry);
             }
           ).fail(
             function( reason )


### PR DESCRIPTION
Reproduction steps:
1. MCP | Projects
2. Click on a project from a list
3. Select "Commit History" tab and click on the first element trying to expand its log
Problem: nothing is shown.

Fix: js code is using clone() function to replicate section from Commit History into Latest Commit tab. This was leaving original collapsible data target the same. Added extra logic to update cloned element's <a>[data-target] attribute and \<div\>[id] attribute to make them unique compared to the original element.